### PR TITLE
Improve perf by dropping GH fork button embeds

### DIFF
--- a/partials/main.html
+++ b/partials/main.html
@@ -113,11 +113,6 @@
 					<div class="col-sm-8 hidden-xs">
 						<div ng-include src="'partials/licenses.html'"></div>
 					</div>
-					<div class="col-xs-12 col-sm-4" style="text-align: right;">
-						<div ng-if="project.host == 'github.com'" class="title2">
-							<iframe src="{{project.forkurl}}" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
-						</div>
-					</div>
 					<div style="clear:both;"></div>
 				</div>			
 			</div> <!-- end repeat block -->


### PR DESCRIPTION
Each GitHub button embed loaded via an iframe introduces additional network overhead of a few seconds (2.6/2.9s in a few cases on cable). 

![screen shot 2016-09-03 at 9 50 09 am](https://cloud.githubusercontent.com/assets/110953/18226309/d9a8f176-71bb-11e6-9c97-9b7e82ec6d08.jpg)

This PR proposes dropping them in favor of folks clicking through to the repo link at the top of each listing instead.

![screen shot 2016-09-03 at 9 48 08 am](https://cloud.githubusercontent.com/assets/110953/18226311/e5c28a3a-71bb-11e6-8fe1-836a5f08197a.jpg)

The impact of this change is we also get to remove 92 additional requests from the current network waterfall:

![screen shot 2016-09-03 at 9 51 30 am](https://cloud.githubusercontent.com/assets/110953/18226317/17b25aca-71bc-11e6-9f0d-8cf8928d86b4.jpg)

which is ⭐ but also nixes 100KB+ from the overall payload.

Reviewer: @samccone 

