### PR TITLE
Remove bg-image src for media

### DIFF
--- a/src/code-nasa-projects.html
+++ b/src/code-nasa-projects.html
@@ -108,9 +108,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       @media (min-width: 768px) {
         :host {
-          background-image: url('/images/backgrounds/projects.jpg'),
-                            url('/images/backgrounds/projects-bottom.jpg'),
-                            linear-gradient(0deg, #323D44, transparent 1300px);
           background-position: center top, center 106vw, center bottom;
           background-size: 100%;
         }


### PR DESCRIPTION
Purpose of this PR is removing `background-image` for media query.

<hr>

I found that background resources for project page are loaded 2 times when user is resizing the window. 
Its because of 
https://github.com/nasa/code-nasa-gov/blob/master/src/code-nasa-projects.html#L21
https://github.com/nasa/code-nasa-gov/blob/master/src/code-nasa-projects.html#L111

On real page it costs 63 ms (no throttling).

![code nasa gov profiling](https://cloud.githubusercontent.com/assets/6231516/20648902/bd76cbb6-b4bb-11e6-8b90-bf7bbe4733f6.png)

In addition, it happens _only_ after first load (cleaned cache).

Here some of resources loading on localserver
 - Before fixing  - http://take.ms/cF7OH
 - After fixing - http://take.ms/6cw18
