### PR TITLE
Changed URL for SRA to https://softwarerelease.ndc.nasa.gov/

### DIFF
--- a/src/code-nasa-guide.html
+++ b/src/code-nasa-guide.html
@@ -163,7 +163,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <h2>1</h2>
         <div class="description">
           <p>
-            Submit a request to release your project as Open Source to your center SRA (Software Release Authority) at <a href="https://code.nasa.gov/#/SRA">code.nasa.gov/#/SRA</a>.
+            Submit a request to release your project as Open Source to your center SRA (Software Release Authority) at <a href="https://softwarerelease.ndc.nasa.gov/">https://softwarerelease.ndc.nasa.gov/</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Changed URL for code.nasa.gov/#/SRA which doesn't go anywhere useful to https://softwarerelease.ndc.nasa.gov/