### PR TITLE
Fix bug with only 12 results showing

### DIFF
--- a/src/code-nasa-projects.html
+++ b/src/code-nasa-projects.html
@@ -68,15 +68,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         font-style: italic;
       }
 
-      iron-list {
-        /**
-         * HACK(keanulee): iron-list needs to have padding-top so that it occupies the entire height of the
-         * scroll area.
-         */
-        margin-top: -100vw;
-        padding-top: 100vw;
-      }
-
       .meta.explain {
         margin-top:1.5em;
       }


### PR DESCRIPTION
This was the bug. I deleted `.meta:` from the previous code. I should have thought about how it affects the css below it...

So, because there was an invalid selector above the `iron-list` selector it was invalidated previously. I just learned that that is how the browser reads a css file:

For example:

```css
.dog:

.dog {
  font-size: 99px;
}

.dog {
  font-size: 99px;
}
```

The first would be invalidated, while the second works.

So, it was not being used, and when I deleted the `.meta:` it was being used causing that strange bug. So I just deleted `iron-list` instead of putting `.meta:` back in as it wasn't doing anything.